### PR TITLE
Fixed exclude list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,9 @@ buildscript {
 
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'scala'
+apply plugin: 'eclipse'
 
-version = "2.5"
+version = "2.5.1"
 group = "btfubackup.BTFU"
 archivesBaseName = "BTFU-1.16"
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -6,7 +6,7 @@ showAsResourcePack = false
 
 [[mods]]
 modId = "btfu"
-version = "2.5.0"
+version = "2.5.1"
 entryClass = "btfubackup.BTFU"
 displayName = "BTFU"
 displayURL = "https://github.com/elytra/BTFU"

--- a/src/main/scala/btfubackup/BTFUConfig.scala
+++ b/src/main/scala/btfubackup/BTFUConfig.scala
@@ -63,9 +63,9 @@ object BTFUConfig {
     .define("disableInteractive", false)
 
   builder.comment("excluded paths",
-    "For normal operation, see rsync manual for --exclude.  For systemless mode, see java.nio.file.PathMatcher.",
+    "For normal operation, see rsync manual for --exclude.  For systemless mode, see java.nio.file.PathMatcher (prefix \"glob:\" is used by internal code, do not add it).",
     "Patterns are for relative paths from the server root."
-  ).define("exclude", List.empty[String].asJava)
+  ).defineList("exclude", List.empty[String].asJava, o => o != null && o.isInstanceOf[String])
 
   builder.comment("maximum backup age",
     "Backups older than this many days will be deleted prior to logarithmic pruning, -1 to keep a complete history"


### PR DESCRIPTION
- Bumped version from 2.5.0 to 2.5.1
- Added notation to the exclude list that the code already includes the "glob:" prefix